### PR TITLE
Add minimal permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves the CodeQL code scanning alert **"Workflow does not contain permissions"** (Medium severity) in `.github/workflows/test.yml`.

The workflow had no `permissions` block, so it inherited the default (potentially broad) `GITHUB_TOKEN` permissions. This workflow only checks out code and runs tests/typecheck, so it needs read-only access to repository contents.

## Change

Added a top-level `permissions` block scoped to the minimum required:

```yaml
permissions:
  contents: read
```

This follows the principle of least privilege and clears the CodeQL alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QBSuhQWFJzzjY2Z41EmR5

---
_Generated by [Claude Code](https://claude.ai/code/session_014QBSuhQWFJzzjY2Z41EmR5)_